### PR TITLE
Fix typo in port environment

### DIFF
--- a/cmd/apidemic/main.go
+++ b/cmd/apidemic/main.go
@@ -36,7 +36,7 @@ func main() {
 					Name:   "port",
 					Usage:  "http port to run",
 					Value:  3000,
-					EnvVar: "POSRT",
+					EnvVar: "PORT",
 				},
 			},
 		},


### PR DESCRIPTION
just a small typo in the environment variable name.