### PR TITLE
0.7 - Feature support list of entities response

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,20 @@ In case you need to mimic endpoints which respond to requests other than GET the
 
 Currently supported HTTP methods are: `OPTIONS`, `GET`, `POST`, `PUT`, `DELETE`, `HEAD`, default is `GET`. Please open an issue if you think there should be others added.
 
+#### List endpoints
+
+In case you need your endpoint to return an array of entities instead of a single one, just add a `max_count` key into your API description
+
+```json
+{
+  "endpoint": "test",
+  "max_count": 2,
+  "payload": {
+    "name: first_name": "anton"
+  }
+}
+```
+
 # Tags
 Apidemic uses tags to annotate what kind of fake data to generate and also control different requrements of fake data.
 

--- a/api.go
+++ b/api.go
@@ -12,7 +12,7 @@ import (
 )
 
 // Version is the version of apidemic. Apidemic uses semver.
-const Version = "0.3"
+const Version = "0.6"
 
 var maxItemTime = cache.DefaultExpiration
 
@@ -27,6 +27,7 @@ var allowedHttpMethods = []string{"OPTIONS", "GET", "POST", "PUT", "DELETE", "HE
 type API struct {
 	Endpoint   string                 `json:"endpoint"`
 	HTTPMethod string                 `json:"http_method"`
+	MaxCount   int32                  `json:"max_count"`
 	Payload    map[string]interface{} `json:"payload"`
 }
 
@@ -74,7 +75,7 @@ func RegisterEndpoint(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	obj := NewObject()
-	err = obj.Load(a.Payload)
+	err = obj.Load(a.Payload, a.MaxCount)
 	if err != nil {
 		RenderJSON(w, http.StatusInternalServerError, NewResponse(err.Error()))
 		return

--- a/api.go
+++ b/api.go
@@ -12,7 +12,7 @@ import (
 )
 
 // Version is the version of apidemic. Apidemic uses semver.
-const Version = "0.6"
+const Version = "0.7"
 
 var maxItemTime = cache.DefaultExpiration
 

--- a/json_test.go
+++ b/json_test.go
@@ -5,20 +5,41 @@ import (
 	"encoding/json"
 	"io/ioutil"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-func TestParseJSONData(t *testing.T) {
-	data, err := ioutil.ReadFile("fixtures/sample.json")
-	if err != nil {
-		t.Fatal(err)
-	}
-	ob, err := parseJSONData(bytes.NewReader(data))
-	if err != nil {
-		t.Error(err)
-	}
+func TestParseJSONDataOfNonArray(t *testing.T) {
+	ob := loadObject(t, "fixtures/sample.json")
 
-	_, err = json.MarshalIndent(ob, "", "\t")
-	if err != nil {
-		t.Error(err)
-	}
+	res, err := json.MarshalIndent(ob, "", "\t")
+	require.NoError(t, err)
+
+	str := string(res)
+	assert.Equal(t, "{", str[:1])
+	assert.Equal(t, "}", str[len(str)-1:])
+}
+
+func TestParseJSONDataOfArray(t *testing.T) {
+	ob := loadObject(t, "fixtures/sample.json")
+	ob.IsArray = true
+	ob.MaxCount = 10
+
+	res, err := json.MarshalIndent(ob, "", "\t")
+	require.NoError(t, err)
+
+	str := string(res)
+	assert.Equal(t, "[", str[:1])
+	assert.Equal(t, "]", str[len(str)-1:])
+}
+
+func loadObject(t *testing.T, fixture string) (*Object) {
+	data, err := ioutil.ReadFile(fixture)
+	require.NoError(t, err)
+
+	ob, err :=  parseJSONData(bytes.NewReader(data))
+	require.NoError(t, err)
+
+	return ob
 }


### PR DESCRIPTION
> Looks much convenient , we don't want to limit the payload to map[sting]interface{} there are cases you want to serve array of objects instead of maps.

